### PR TITLE
Example 4.2 - Building a Dataframe for Backtesting

### DIFF
--- a/Python Data API - Data+ & Data Feed/4.2 - Macrobond Data API - Building Backtesting Dataframe.ipynb
+++ b/Python Data API - Data+ & Data Feed/4.2 - Macrobond Data API - Building Backtesting Dataframe.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 4.2 - Macrobond Data API for Python - Building Backtesting Dataframe\n",
+    "\n",
+    "*Using Macrobond Data API for Python to query revision history for one or more time series and return only vintage series relevant to a list of rebalance dates. Given a list of rebalance dates for a back-testing model, this script identifies the closest previous vintage series for each date, and returns these series in a unified dataframe. The script has been optimized to handle one or many series requests for the same rebalance dates, and to return the outputed dataframes in a dictionary of dataframes*\n",
+    "\n",
+    "This notebook aims to provide an example of how to use methods from Macrobond Data API for Python to work with Revision History and build out a dataframe for backtesting.\n",
+    "\n",
+    "You can find a full description of all methods and parameters used in this example in the [documentation of the API](https://macrobond.github.io/macrobond-data-api/common/api.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "\n",
+    "## Importing Packages"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import macrobond_data_api as mda\n",
+    "import pandas as pd\n",
+    "\n",
+    "from datetime import datetime\n",
+    "from dateutil.tz import tzutc\n",
+    "\n",
+    "pd.set_option('display.max_rows', None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "***\n",
+    "### Define Ticker Universe\n",
+    "\n",
+    "Define tickers of interest and rebalance dates in tzutc format. Use get_revision_info() to return all possible vintage timestamps for each series, formatting dates in dataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tickers = ['krnaac0145', 'zanaac0004']\n",
+    "rebalance_dates = [datetime(2019, 6, 1, tzinfo=tzutc()), datetime(2019, 7, 1, tzinfo=tzutc()), datetime(2021,8, 1, tzinfo=tzutc()), datetime(2021,9, 1, tzinfo=tzutc()), datetime(2021,10, 1, tzinfo=tzutc()), datetime(2021,11, 1, tzinfo=tzutc()), datetime(2021, 12, 1, tzinfo=tzutc()), datetime(2022, 1, 1, tzinfo=tzutc())] \n",
+    "\n",
+    "data_frames = [mda.get_revision_info(tickers[n])[0].to_pd_data_frame() for n in range(len(tickers))] \n",
+    "data_frames=[data_frames[n].groupby(data_frames[n].columns.to_list()[:-2])[\"vintage_time_stamps\"].agg(list).reset_index() for n in range(len(data_frames))]\n",
+    "timestamps = [pd.DataFrame(data_frames[n].loc[0]['vintage_time_stamps'], columns=['vintage_time_stamp']) for n in range(len(data_frames))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Get all vintage series for each ticker of interest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use mda.get_all_vintage_series() to return all possible vintages for a ticker."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vint_dfs_full = [mda.get_all_vintage_series(ticker).to_pd_data_frame().set_index('date') for ticker in tickers]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adjusting column names for error handling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vint_dfs_full=[vint_dfs_full[n].rename(columns={vint_dfs_full[n].columns[0]:'pre_vintage'}) for n in range(len(vint_dfs_full))] "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating list of relevant vintage timestamps for each inputed rebalance date. \n",
+    "\n",
+    "Each inputed rebalanced date is matched with the closest, previous vintage timestamp available for the series. \n",
+    "We include error handling for situations where the inputed rebalance date is earlier than all existing vintage timestamps for a series. In this case, a Warning issued and the earliest record of a series is used as the nearest, previous vintage series. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vint_ts_list = []\n",
+    "\n",
+    "for n in range(len(timestamps)):\n",
+    "    temp_list = []\n",
+    "    for rebalance_date in rebalance_dates:\n",
+    "        if timestamps[n]['vintage_time_stamp'].loc[0]>rebalance_date:   # In case where inputed rebalance dates is earlier than all available vintage timestamps for a series, warning is issued and first release of the series is used for the vintage data\n",
+    "            print('Warning: The {} rebalance date is earlier than all vintages available for the series, \\033[1m\\x1B[3m{}\\033[0;0m\\x1B[0m, where the earliest vintage timestamp available is {}. The first release will be used for this reblanace date.'.format(rebalance_date, tickers[n], timestamps[n]['vintage_time_stamp'].loc[0]))\n",
+    "            temp_list.append(vint_dfs_full[n].columns[0])\n",
+    "        else: # In case where vintage timestamps exist previous to the rebalance date, the most recent previous vintage timeseries is selected as the vintage data for this rebalance date.\n",
+    "            temp_list.append(timestamps[n]['vintage_time_stamp'].loc[timestamps[n]['vintage_time_stamp']<rebalance_date].iloc[-1])\n",
+    "    vint_ts_list.append(temp_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Return relevant vintage data\n",
+    "\n",
+    "Filter full vintage dataframe to include only vintage timsestamps identified with the rebalance dates above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_dfs = [vint_dfs_full[n][vint_ts_list[n]] for n in range(len(vint_dfs_full))]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rename columns with rebalance dates for formatting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for df in final_dfs:\n",
+    "    df.columns=rebalance_dates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating dataframe dictionary\n",
+    "\n",
+    "Storing backtest dataframes in dictionary to link with relevant ticker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vint_dfs_dict = {}\n",
+    "for i in range(len(tickers)):\n",
+    "    vint_dfs_dict[tickers[i]]=final_dfs[i]\n",
+    "\n",
+    "for key in range(len(list(vint_dfs_dict.keys()))):\n",
+    "    print('{}:'.format(list(vint_dfs_dict.keys())[key]))\n",
+    "    display(vint_dfs_dict[list(vint_dfs_dict.keys())[key]])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This script in this notebook builds a dataframe for backtesting that can handle single or multiple tickers. For each rebalance date inputted for a backtesting strategy, the script identifies the closest, previous vintage timestamp available for each ticker and returns the relevant vintage timeseries. This script was developed so users could easily build a backtesting dataframe and be confident that the vintage series returned are the nearest, previous vintage data, and not just the nearest vintage data. 